### PR TITLE
Update user.js

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -38,7 +38,7 @@ module.exports = function(module, downloads, users, mainopts) {
   }
 
   User.prototype.info = function(options, callback) {
-    return users.get('org.couchdb.user:hughsk', callback)
+    return users.get('org.couchdb.user:' + this.name, callback)
   }
 
   return User


### PR DESCRIPTION
This patch fixes an issue where registry.user([user]).info() will always return data on hughsk.
