### PR TITLE
make it so we can configure the nano module itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/index.js
+++ b/index.js
@@ -27,9 +27,15 @@ exports.defaults = function(defaults){
 }
 
 function stats(registry, mainopts) {
+  if (typeof registry === 'object') {
+    mainopts = registry
+    registry = undefined
+  }
+
   mainopts = merge({}, GLOBAL_DEFAULTS, mainopts, {registry:registry});
-  
-  var nano = require('nano')(mainopts.registry)
+  var nanoConf = merge({url: mainopts.registry}, mainopts.nano)
+
+  var nano = require('nano')(nanoConf)
     , modules = nano.db.use(mainopts.modules)
     , users = nano.db.use(mainopts.users)
     , downloadUrl = mainopts.downloads
@@ -113,4 +119,3 @@ function stats(registry, mainopts) {
 
   return registry
 }
-

--- a/package.json
+++ b/package.json
@@ -4,17 +4,20 @@
   "description": "Convenience module for getting back data from an NPM registry",
   "main": "index.js",
   "dependencies": {
-    "event-stream": "~3.0.12",
     "JSONStream": "~0.6.2",
-    "stream-reduce": "~1.0.3",
-    "through": "~2.3.6",
-    "nano": "~3.3.8",
+    "event-stream": "~3.0.12",
+    "lodash.merge": "~3.3.2",
+    "nano": "^6.2.0",
     "request": "~2.45.0",
-    "lodash.merge": "~3.3.2"
+    "stream-reduce": "~1.0.3",
+    "through": "~2.3.6"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "tap": "^5.4.2"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tap --coverage ./test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,50 @@
+/* global describe, it */
+
+var npmStats = require('./')
+var expect = require('chai').expect
+
+require('tap').mochaGlobals()
+require('chai').should()
+
+describe('npm-stats', function () {
+  describe('module', function () {
+    it('info() fetches info for module', function (done) {
+      npmStats().module('lodash').info(function (err, lodash) {
+        expect(err).to.equal(null)
+        lodash.name.should.equal('lodash')
+        return done()
+      })
+    })
+  })
+
+  describe('user', function () {
+    it('count() fetches count of npm modules', function (done) {
+      npmStats().user('bcoe').count(function (err, count) {
+        expect(err).to.equal(null)
+        count.should.be.gt(0)
+        return done()
+      })
+    })
+  })
+
+  describe('configuration', function () {
+    it('allows registry URL to be overridden', function (done) {
+      npmStats('https://registry.npmjs.org', {modules: ''}).module('lodash').info(function (err, lodash) {
+        expect(err).to.equal(null)
+        lodash.name.should.equal('lodash')
+        return done()
+      })
+    })
+
+    it('allows registry URL to be overridden with configuration object', function (done) {
+      npmStats({
+        modules: '',
+        registry: 'https://registry.npmjs.org'
+      }).module('lodash').info(function (err, lodash) {
+        expect(err).to.equal(null)
+        lodash.name.should.equal('lodash')
+        return done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Problem Statement

We're using `npm-stats` on the npm website, and I'd like to also pull it into the behind-the-firewall version of `newww` that we deploy with npm On-Site.

There's a blocker however, I need to be able to kick the `proxy` variable along to `nano` (otherwise this module won't work in many big companies).

## Solution

* Good news, I've made it so configuration can be kicked along to `nano`, you simply set the `mainopts.nano` configuration object \o/
* I've upgraded the version of `nano` to a newer version, one which actually allows request options to be modified.
* I've added unit tests with test-coverage (I didn't want to accidentally break your module on you).

<img width="629" alt="screen shot 2016-02-01 at 5 33 47 pm" src="https://cloud.githubusercontent.com/assets/194609/12737020/fc8f2a08-c909-11e5-8b17-380bf74bc30a.png">

Thanks for the great work on this module.
